### PR TITLE
upgrade ws and dont use upgradeReq

### DIFF
--- a/express-ws-routes.js
+++ b/express-ws-routes.js
@@ -206,11 +206,11 @@ exports.verifyClient = function(app, options) {
  * @returns {function}
  */
 exports.onConnection = function() {
-	return function(webSocket) {
-		var handler = webSocket.upgradeReq._websocketHandler;
-		delete webSocket.upgradeReq._websocketHandler;
+	return function(webSocket, req) {
+		var handler = req._websocketHandler;
+		delete req._websocketHandler;
 
 		// TODO: catch error?
-		handler(webSocket, webSocket.upgradeReq);
+		handler(webSocket, req);
 	};
 };

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "array-flatten": "^1.1.1",
     "debug": "^2.2.0",
-    "ws": "^0.8.0 || ^1.0.0"
+    "ws": "^6.1.2"
   },
   "peerDependencies": {
     "express": "^4.5.0"


### PR DESCRIPTION
Hello!

  This library no long works with ws > 2.0.0 (specifically https://github.com/websockets/ws/pull/1099)

  I've fixed that, and it now works with modern `ws`! I've also upgrade the `ws` dependency as there have been heaps of improvements over the years.

Thanks, and let me know if I can do anything else to help!